### PR TITLE
[bazel] avoid conflicting with 'server' workspace

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -444,7 +444,7 @@ static int StartServer(int socket) {
   // for the existing server. If might be that the server dies and the cmdline
   // file stays there, but that is not a problem, since we always check the
   // server, too.
-  WriteFile(argument_string, globals->options.output_base + "/server/cmdline");
+  WriteFile(argument_string, globals->options.output_base + "/bazel-server/cmdline");
 
   // unless we restarted for a new-version, mark this as initial start
   if (globals->restart_reason == NO_RESTART) {
@@ -599,7 +599,7 @@ static int ConnectToServer(bool start) {
          "can't create AF_UNIX socket");
   }
 
-  string server_dir = globals->options.output_base + "/server";
+  string server_dir = globals->options.output_base + "/bazel-server";
 
   // The server dir has the socket, so we don't allow access by other
   // users.
@@ -978,7 +978,7 @@ static void KillRunningServerIfDifferentStartupOptions() {
   }
 
   close(socket);
-  string cmdline_path = globals->options.output_base + "/server/cmdline";
+  string cmdline_path = globals->options.output_base + "/bazel-server/cmdline";
   string joined_arguments;
 
   // No, /proc/$PID/cmdline does not work, because it is limited to 4K. Even
@@ -1382,7 +1382,7 @@ static void ComputeBaseDirectories(const string &self_path) {
   globals->options.output_base =
       MakeCanonical(globals->options.output_base.c_str());
   globals->lockfile = globals->options.output_base + "/lock";
-  globals->jvm_log_file = globals->options.output_base + "/server/jvm.out";
+  globals->jvm_log_file = globals->options.output_base + "/bazel-server/jvm.out";
 }
 
 static void CheckEnvironment() {

--- a/src/main/cpp/blaze_globals.h
+++ b/src/main/cpp/blaze_globals.h
@@ -44,7 +44,7 @@ struct GlobalVariables {
   string lockfile;  // = <output_base>/lock
   int lockfd;
 
-  string jvm_log_file;  // = <output_base>/server/jvm.out
+  string jvm_log_file;  // = <output_base>/bazel-server/jvm.out
 
   string cwd;
 


### PR DESCRIPTION
If someone teaches me how to define constants in CPP I can also define this folder as a constant.
I searched code and didn't find anything else that was using this same folder.
